### PR TITLE
Configured autoloader to be properly required when installing via composer.

### DIFF
--- a/blacksmith
+++ b/blacksmith
@@ -1,9 +1,15 @@
 #!/usr/bin/env php
 <?php
 
+$project_autoload_path = __DIR__.'/../../autoload.php';
+$local_autoload_path   = __DIR__.'/vendor/autoload.php';
+
+$autoload_path = file_exists($project_autoload_path)
+    ? $project_autoload_path
+    : $local_autoload_path;
 
 // Autoload classes
-require __DIR__.'/vendor/autoload.php';
+require_once $autoload_path;
 
 
 $console = new Blacksmith\Console($argv);

--- a/composer.json
+++ b/composer.json
@@ -16,5 +16,6 @@
         "psr-4": {
             "Blacksmith\\": "src/"
         }
-    }
+    },
+    "bin": ["blacksmith"]
 }


### PR DESCRIPTION
Performing `composer require grahamsutt12/blacksmith` into a brand new (external) project should install the package and make the binary available to the following command:

```bash
$ vendor/bin/blacksmith
```

This can also be aliased to:

```bash
$ alias blacksmith='vendor/bin/blacksmith'
$ blacksmith
# Displays blacksmith terminal prompt.
```