### PR TITLE
Added the make:cmd file and ability to create subdirectories and comm…

### DIFF
--- a/blacksmith
+++ b/blacksmith
@@ -3,6 +3,7 @@
 
 // We define the root of the call
 define('BLACKSMITH_ROOT', getcwd());
+define('BLACKSMITH_COMMANDS_DIR', DIRECTORY_SEPARATOR . 'commands');
 
 // Autoload depending on where we are standing
 $project_autoload_path = __DIR__.'/../../autoload.php';
@@ -24,6 +25,7 @@ $console = new Blacksmith\Console($argv);
 $console->commands = [
     Blacksmith\Commands\HelpCommand::class,
     Blacksmith\Commands\BootstrapCommand::class,
+    Blacksmith\Commands\Make\CmdCommand::class,
     Blacksmith\Examples\SayHello::class,
     Blacksmith\Examples\SayBye::class
 ];

--- a/src/Commands/make/CmdCommand.php
+++ b/src/Commands/make/CmdCommand.php
@@ -1,0 +1,125 @@
+<?php
+
+namespace Blacksmith\Commands\Make;
+
+use Blacksmith\Command;
+
+/**
+ * The "Make Command" Command.
+ *
+ * This command is responsible for creating new commands that will be placed in
+ * the commands directory in the target project's main directory. If provided 
+ * subdirectories to create the command in, the CmdCommand class will place the
+ * new command in those subdirectories.
+ */
+
+class CmdCommand extends Command {
+
+    // Set the signature for the command
+    const signature       = 'make:cmd';
+
+    // Set the description of the command
+    const description     = 'Creates a new command';
+
+    /**
+     * The full path for the new command.
+     * @var string
+     */
+    protected $command_dir_path = '';
+
+    /**
+     * Main method that will run the
+     * command operation.
+     */
+    public function run()
+    {
+        // Validate argument was passed
+        if (empty($this->getArguments())) {
+            $this->console->output->alert('make:cmd requires an argument.');
+            return;
+        }
+
+        $this->createCommand();
+    }
+
+    /**
+     * Create a new command.
+     *
+     * Gets the provided arguments and creates subdirectories if they do not already exist
+     * for the provided command. The last element in the chain of subdirectories is treated
+     * as the name of the callabale command, in which we create a template command file for.
+     *
+     * For example:
+     *
+     *      php blacksmith make:cmd this:is:my:command
+     *
+     * results in the following path being created:
+     *
+     *      my-project/commands/this/is/my/Command.php
+     */
+    protected function createCommand()
+    {
+        $arg = $this->getArguments()[0];
+
+        $sub_dir_names = explode(DIRECTORY_SEPARATOR, $arg);
+        $command_name  = $sub_dir_names[count($sub_dir_names) - 1];
+
+        // Remove the command name from the list of sub dirs
+        unset($sub_dir_names[count($sub_dir_names) - 1]);
+
+        $this->createSubDirectories($sub_dir_names);
+        $this->createCommandFile($command_name);
+    }
+
+    /**
+     * Create the subdirectories for the new command.
+     *
+     * @param array $sub_dirs
+     *      The array of subdirectory names to create for the new command.
+     */
+    protected function createSubDirectories(array $sub_dirs)
+    {
+        // Get the path to the /commands folder
+        $blacksmith_cmd_dir = BLACKSMITH_ROOT . BLACKSMITH_COMMANDS_DIR;
+
+        // Form the full path with sub dirs for the new command
+        // e.g. "my-project/commands/my/new/Cmd.php"
+        $this->command_dir_path = $blacksmith_cmd_dir . DIRECTORY_SEPARATOR . implode(DIRECTORY_SEPARATOR, $sub_dirs);
+
+        if (!file_exists($this->command_dir_path)) {
+            mkdir($this->command_dir_path, 0755, true);
+        }
+    }
+
+    /**
+     * Create the .php file for the new command.
+     *
+     * @param string $command_name
+     *      The name of the new command to create the command file for.
+     */
+    protected function createCommandFile($command_name)
+    {
+        // Check if the command already has the .php extension
+        $file_extension = strtolower(pathinfo($command_name, PATHINFO_EXTENSION));
+
+        if ($file_extension !== 'php') {
+            $command_name .= '.php';
+        }
+
+        $command_file_name      = ucfirst($command_name);
+        $command_file_full_path = $this->command_dir_path . DIRECTORY_SEPARATOR . $command_file_name;
+
+        // Check if the command already exists
+        if (file_exists($command_file_full_path)) {
+            $this->console->output->alert('Command already exists.');
+            return;
+        }
+
+        // Create the file for the new command
+        fopen($command_file_full_path, 'w');
+
+        $this->console->output->println('File created at: ' . $command_file_full_path);
+        $this->console->output->println();
+        $this->console->output->success('Command ' . $this->getArguments()[0] . ' created successfully.');
+    }
+}

--- a/src/IO/Output.php
+++ b/src/IO/Output.php
@@ -72,5 +72,13 @@ class Output {
         $this->println($output);
     }
 
-
+    /**
+     * Success message
+     * Prints a success message to the console
+     */
+    public function success($message)
+    {
+        $output = $this->decorator->decorate($message, 'green');
+        $this->println($output);
+    }
 }


### PR DESCRIPTION
…and file when providing a new command.

You should be able to perform the following command now:

```bash
$ php blacksmith make:cmd my/new/command
```

And consequentially a file should be generated in the respective subdirectories:

```
some-project/commands/my/new/Command.php
```

Note: The name of the command will be the new name of the file but with a capital letter.

**Other Misc. Changes**

* Made use of `DIRECTORY_SEPARATOR` constant so that file paths can be OS agnostic. We should probably update some of the other places in the app to use it, too.
* Added a new `success` message in the `Output.php` class that prints a green message with transparent background to the console.
* Running `make:cmd` command will actually create the `/commands` folder recursively if it doesn't yet exist, so we may actually be able to remove it from the `bootstrap` file.
