### PR TITLE
Moved Argument logic into its own class.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,8 @@
     "description": "A CLI command structure for your php processes",
     "type": "library",
     "require-dev": {
-        "phpunit/phpunit": "^5.7"
+        "phpunit/phpunit": "^5.7",
+        "mikey179/vfsStream": "1.6.4"
     },
     "license": "MIT",
     "authors": [

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "f7e00cfd2c0fe9c801b116d88cdb08ae",
-    "content-hash": "4176aeefc3329b674d9608273d843378",
+    "hash": "7bf073fc968d886c91bc57c13d1dd1d5",
+    "content-hash": "91d726d6e236481f8d785f45dcaf0311",
     "packages": [],
     "packages-dev": [
         {
@@ -61,6 +61,52 @@
                 "instantiate"
             ],
             "time": "2015-06-14 21:17:01"
+        },
+        {
+            "name": "mikey179/vfsStream",
+            "version": "v1.6.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/mikey179/vfsStream.git",
+                "reference": "0247f57b2245e8ad2e689d7cee754b45fbabd592"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/mikey179/vfsStream/zipball/0247f57b2245e8ad2e689d7cee754b45fbabd592",
+                "reference": "0247f57b2245e8ad2e689d7cee754b45fbabd592",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.6.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "org\\bovigo\\vfs\\": "src/main/php"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Frank Kleine",
+                    "homepage": "http://frankkleine.de/",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Virtual file system to mock the real file system in unit tests.",
+            "homepage": "http://vfs.bovigo.org/",
+            "time": "2016-07-18 14:02:57"
         },
         {
             "name": "myclabs/deep-copy",

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -8,5 +8,13 @@
             <directory suffix=".test.php">tests</directory>
         </testsuite>
     </testsuites>
+    <filter>
+        <whitelist processUncoveredFilesFromWhitelist="true">
+            <directory suffix=".php">src</directory>
+            <exclude>
+                <directory suffix=".php">src/Examples</directory>
+            </exclude>
+        </whitelist>
+    </filter>
 
 </phpunit>

--- a/src/Argument.php
+++ b/src/Argument.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Blacksmith;
+
+/**
+ * The Argument Class
+ *
+ * This class is the base class that holds common properties and
+ * functionality across all types of Argument objects that inherit
+ * from this class.
+ */
+abstract class Argument {
+
+    /**
+     * The raw argument that was passed in by the user.
+     * @var string
+     */
+    protected $raw_arg;
+
+    /**
+     * Constructor
+     *
+     * @param string $raw_arg
+     *      The raw argument provided by the user.
+     */
+    public function __construct($raw_arg)
+    {
+        $this->raw_arg = $raw_arg;
+    }
+
+    /**
+     * Return the raw argument.
+     *
+     * @return string
+     */
+    public function getRawArgument()
+    {
+        return $this->raw_arg;
+    }
+}

--- a/src/Arguments/make/CmdArgument.php
+++ b/src/Arguments/make/CmdArgument.php
@@ -1,0 +1,127 @@
+<?php
+
+namespace Blacksmith\Arguments\Make;
+
+use Blacksmith\Argument;
+
+/**
+ * The "Make Command" Argument
+ *
+ * This class is responsible for easing the management of arguments
+ * for the "make:cmd" command as an object to prevent app-wide
+ * string manipulation.
+ */
+class CmdArgument extends Argument {
+
+    /**
+     * The array of subdirectories.
+     * @var array
+     */
+    protected $sub_dirs;
+
+    /**
+     * The name of the command to create.
+     * @var string
+     */
+    protected $command_name;
+
+    /**
+     * Constructor
+     *
+     * @param string $raw_arg
+     *      The raw argument provided by the user.
+     */
+    public function __construct($raw_arg)
+    {
+        parent::__construct($raw_arg);
+        $this->parseArgument();
+    }
+
+    /**
+     * Parse the argument and determine the subdirectory path and command name.
+     */
+    protected function parseArgument()
+    {
+        $sub_dir_names = explode(DIRECTORY_SEPARATOR, $this->raw_arg);
+        $command_name  = $sub_dir_names[count($sub_dir_names) - 1];
+
+        // Remove the command name from the list of sub dirs
+        unset($sub_dir_names[count($sub_dir_names) - 1]);
+
+        $this->sub_dirs     = $sub_dir_names;
+        $this->command_name = $command_name;
+    }
+
+    /**
+     * Returns the name of the command that was parsed from the argument.
+     *
+     * @return string
+     */
+    public function getCommandName()
+    {
+        return $this->command_name;
+    }
+
+    /**
+     * Returns the sub directory path as a string instead of as an array.
+     *
+     * @return string
+     */
+    public function getSubDirPath()
+    {
+        return implode(DIRECTORY_SEPARATOR, $this->sub_dirs);
+    }
+
+    /**
+     * Returns the possible signature of the argument.
+     *
+     * @return string
+     */
+    public function getSignature()
+    {
+        $command_name = $this->command_name;
+
+        // Remove php extension if it exists
+        if ($this->hasPhpExtension()) {
+            $command_name = str_replace('.php', '', $this->command_name);
+        }
+
+        // Convert to underscore_notation
+        $command_name = strtolower(preg_replace('/(?<!^)[A-Z]/', '_$0', $command_name));
+
+        return str_replace(DIRECTORY_SEPARATOR, ":", $this->getSubDirPath()) . ":" . $command_name;
+    }
+
+    /**
+     * Returns the name of the command as it would appear as a .php file.
+     */
+    public function getCommandFileName()
+    {
+        $command_name = $this->command_name;
+
+        if (!$this->hasPhpExtension()) {
+            $command_name = $command_name . '.php';
+        }
+
+        // Captialize the first letter and only the first letter
+        $first_letter = mb_substr($command_name, 0, 1, 'utf-8');
+        $first_letter = strtoupper($first_letter);
+
+        $command_name[0] = $first_letter;
+
+        return $command_name;
+    }
+
+    /**
+     * Checks if the the user provided a .php extension in the command name.
+     *
+     * @return boolean
+     */
+    public function hasPhpExtension()
+    {
+        // Check if the command already has the .php extension
+        $file_extension = strtolower(pathinfo($this->command_name, PATHINFO_EXTENSION));
+
+        return $file_extension === 'php';
+    }
+}

--- a/src/Console.php
+++ b/src/Console.php
@@ -47,7 +47,7 @@ class Console {
      */
     public function setRawArguments(array $args)
     {
-        $this->command = null;
+        $this->command   = null;
         $this->arguments = $args;
     }
 
@@ -69,14 +69,14 @@ class Console {
      */
     public function initCommand()
     {
-        if(sizeof($this->arguments) <= 1) {
+        if (sizeof($this->arguments) <= 1) {
             return new HelpCommand($this);
         }
 
         $signature = $this->arguments[1];
 
         foreach ($this->commands as $cmd) {
-            if($cmd::signature === $signature) {
+            if ($cmd::signature === $signature) {
                 return new $cmd($this);
             }
         }
@@ -87,9 +87,10 @@ class Console {
      */
     public function getCommand()
     {
-        if( !$this->command ){
+        if (!$this->command) {
             $this->command = $this->initCommand();
         }
+
         return $this->command;
     }
 
@@ -102,14 +103,12 @@ class Console {
      */
     public function handle()
     {
-
         if (is_null($this->getCommand())) {
             $this->output->println("Command was not found.", 'red');
             exit;
         }
 
         $this->command->run();
-
     }
 
 }

--- a/tests/Arguments/make/CmdArgumentTest.test.php
+++ b/tests/Arguments/make/CmdArgumentTest.test.php
@@ -1,0 +1,119 @@
+<?php
+
+namespace Blacksmith;
+
+use Blacksmith\Arguments\Make\CmdArgument;
+
+
+class CmdArgumentTest extends \PHPUnit_Framework_TestCase {
+
+    /**
+     * The test sub directory path.
+     * @var string
+     */
+    protected $sub_dirs;
+
+    /**
+     * The test name of the command.
+     * @var string
+     */
+    protected $command_name;
+
+    /**
+     * The raw test argument.
+     * @var string
+     */
+    protected $arg;
+
+    /**
+     * The CmdArgument object we are testing.
+     * @var Blacksmith\Arguments\Make\CmdArgument
+     */
+    protected $cmd_arg;
+
+    public function setUp()
+    {
+        parent::setUp();
+
+        $this->sub_dirs     = 'path/to/subdir';
+        $this->command_name = 'mycommand';
+        $this->arg          = $this->sub_dirs . DIRECTORY_SEPARATOR . $this->command_name;
+
+        $this->cmd_arg = new CmdArgument($this->arg);
+    }
+
+    public function tearDown()
+    {
+        $this->sub_dirs     = null;
+        $this->command_name = null;
+        $this->arg          = null;
+
+        $this->cmd_arg = null;
+
+        parent::tearDown();
+    }
+
+    public function testParseArgumentProperlySetsSubDirs()
+    {
+        $this->assertEquals($this->sub_dirs, $this->cmd_arg->getSubDirPath());
+    }
+
+    public function testParseArgumentProperlySetsCommandName()
+    {
+        $this->assertEquals($this->command_name, $this->cmd_arg->getCommandName());
+    }
+
+    public function testGetRawArgumentReturnsTheOriginalArgumentPassed()
+    {
+        $this->assertEquals($this->arg, $this->cmd_arg->getRawArgument());
+    }
+
+    public function testGetSignatureReturnsTheExpectedSignatureOfTheNewCommand()
+    {
+        $expected_signature = str_replace(DIRECTORY_SEPARATOR, ":", $this->arg);
+        $this->assertEquals($expected_signature, $this->cmd_arg->getSignature());
+    }
+
+    public function testGetCommandFileNameReturnsTheProspectivePhpFileNameForTheNewCommand()
+    {
+        $expected_command_file_name = ucfirst($this->command_name) . '.php';
+        $this->assertEquals($expected_command_file_name, $this->cmd_arg->getCommandFileName());
+    }
+
+    public function testPassingCommandWithPhpExtensionDoesntAddAdditionalPhpExtension()
+    {
+        $sub_dirs     = 'path/to/subdir';
+        $command_name = 'MyCommand.php';
+        $arg          = $sub_dirs . DIRECTORY_SEPARATOR . $command_name;
+
+        $cmd_arg = new CmdArgument($arg);
+
+        $this->assertEquals($command_name, $cmd_arg->getCommandFileName());
+    }
+
+    public function testPassingCommandWithStudlyCapsReturnsSignatureInUnderscoreNotation()
+    {
+        $sub_dirs     = 'path/to/subdir';
+        $command_name = 'MyCommand.php';
+        $arg          = $sub_dirs . DIRECTORY_SEPARATOR . $command_name;
+
+        $cmd_arg = new CmdArgument($arg);
+
+        $expected_signature = 'path:to:subdir:my_command';
+
+        $this->assertEquals($expected_signature, $cmd_arg->getSignature());
+    }
+
+    public function testPassingCommandWithCamelCaseReturnsSignatureInUnderscoreNotation()
+    {
+        $sub_dirs     = 'path/to/subdir';
+        $command_name = 'myCommand.php';
+        $arg          = $sub_dirs . DIRECTORY_SEPARATOR . $command_name;
+
+        $cmd_arg = new CmdArgument($arg);
+
+        $expected_signature = 'path:to:subdir:my_command';
+
+        $this->assertEquals($expected_signature, $cmd_arg->getSignature());
+    }
+}


### PR DESCRIPTION
Couples other things to point out as well:

- Fixed some format/style issues with some of the code in `src/Console.php`
- Made two classes for an Argument object: `Argument (abstract)` and `CmdArgument`. I made the Argument parent class abstract because I had no reason to make it concrete as of now. I could very easily see this class becoming concrete in the near future for how we deal with standard arguments, however.
- Added unit tests for the `CmdArgument` class.
- Added the `vfsStream` filesystem mock library in `composer.json`. I am going to use this to test that commands get properly created in their respective directories. This will help isolate testing against the filesystem.