### PR TITLE
Removed bad namespace and moved command and argument classes up a dir…

### DIFF
--- a/blacksmith
+++ b/blacksmith
@@ -25,7 +25,7 @@ $console = new Blacksmith\Console($argv);
 $console->commands = [
     Blacksmith\Commands\HelpCommand::class,
     Blacksmith\Commands\BootstrapCommand::class,
-    Blacksmith\Commands\Make\CmdCommand::class,
+    Blacksmith\Commands\MakeCmdCommand::class,
     Blacksmith\Examples\SayHello::class,
     Blacksmith\Examples\SayBye::class
 ];

--- a/src/Arguments/MakeCmdArgument.php
+++ b/src/Arguments/MakeCmdArgument.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Blacksmith\Arguments\Make;
+namespace Blacksmith\Arguments;
 
 use Blacksmith\Argument;
 
@@ -11,7 +11,7 @@ use Blacksmith\Argument;
  * for the "make:cmd" command as an object to prevent app-wide
  * string manipulation.
  */
-class CmdArgument extends Argument {
+class MakeCmdArgument extends Argument {
 
     /**
      * The array of subdirectories.

--- a/src/Commands/MakeCmdCommand.php
+++ b/src/Commands/MakeCmdCommand.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace Blacksmith\Commands\Make;
+namespace Blacksmith\Commands;
 
 use Blacksmith\Command;
-use Blacksmith\Arguments\Make\CmdArgument;
+use Blacksmith\Arguments\MakeCmdArgument;
 use Exception;
 
 /**
@@ -15,7 +15,7 @@ use Exception;
  * new command in those subdirectories.
  */
 
-class CmdCommand extends Command {
+class MakeCmdCommand extends Command {
 
     // Set the signature for the command
     const signature       = 'make:cmd';
@@ -63,7 +63,7 @@ class CmdCommand extends Command {
             return;
         }
 
-        $this->arg = new CmdArgument($args[0]);
+        $this->arg = new MakeCmdArgument($args[0]);
 
         $this->createSubDirectories();
         $this->createCommandFile();

--- a/tests/Arguments/MakeCmdArgumentTest.test.php
+++ b/tests/Arguments/MakeCmdArgumentTest.test.php
@@ -2,10 +2,10 @@
 
 namespace Blacksmith;
 
-use Blacksmith\Arguments\Make\CmdArgument;
+use Blacksmith\Arguments\MakeCmdArgument;
 
 
-class CmdArgumentTest extends \PHPUnit_Framework_TestCase {
+class MakeCmdArgumentTest extends \PHPUnit_Framework_TestCase {
 
     /**
      * The test sub directory path.
@@ -27,7 +27,7 @@ class CmdArgumentTest extends \PHPUnit_Framework_TestCase {
 
     /**
      * The CmdArgument object we are testing.
-     * @var Blacksmith\Arguments\Make\CmdArgument
+     * @var Blacksmith\Arguments\MakeCmdArgument
      */
     protected $cmd_arg;
 
@@ -39,7 +39,7 @@ class CmdArgumentTest extends \PHPUnit_Framework_TestCase {
         $this->command_name = 'mycommand';
         $this->arg          = $this->sub_dirs . DIRECTORY_SEPARATOR . $this->command_name;
 
-        $this->cmd_arg = new CmdArgument($this->arg);
+        $this->cmd_arg = new MakeCmdArgument($this->arg);
     }
 
     public function tearDown()
@@ -86,7 +86,7 @@ class CmdArgumentTest extends \PHPUnit_Framework_TestCase {
         $command_name = 'MyCommand.php';
         $arg          = $sub_dirs . DIRECTORY_SEPARATOR . $command_name;
 
-        $cmd_arg = new CmdArgument($arg);
+        $cmd_arg = new MakeCmdArgument($arg);
 
         $this->assertEquals($command_name, $cmd_arg->getCommandFileName());
     }
@@ -97,7 +97,7 @@ class CmdArgumentTest extends \PHPUnit_Framework_TestCase {
         $command_name = 'MyCommand.php';
         $arg          = $sub_dirs . DIRECTORY_SEPARATOR . $command_name;
 
-        $cmd_arg = new CmdArgument($arg);
+        $cmd_arg = new MakeCmdArgument($arg);
 
         $expected_signature = 'path:to:subdir:my_command';
 
@@ -110,7 +110,7 @@ class CmdArgumentTest extends \PHPUnit_Framework_TestCase {
         $command_name = 'myCommand.php';
         $arg          = $sub_dirs . DIRECTORY_SEPARATOR . $command_name;
 
-        $cmd_arg = new CmdArgument($arg);
+        $cmd_arg = new MakeCmdArgument($arg);
 
         $expected_signature = 'path:to:subdir:my_command';
 


### PR DESCRIPTION
…ectory.

- Removed the directory `/src/Arguments/make` and `/src/Commands/make`.
- Moved file in those directories to `/src/Arguments` and `/src/Commands` respectively.
- Updated the names of the commands and arguments to `/src/Arguments/MakeCmdArgument.php`  and `/src/Commands/MakeCmdCommand.php` respectively.

As a result of these changes, my tests started to pass. I believe this was due to a bad namespace that I was using, specifically `Blacksmith\Arguments\Make\CmdArgument` and `Blacksmith\Commands\Make\CmdCommand` respectively. Not sure why these would fail. Will require some more research from me into PHP's namespace limitations.