### PR TITLE
Created blacksmith command registry file, Config object for app depen…

### DIFF
--- a/blacksmith
+++ b/blacksmith
@@ -1,10 +1,6 @@
 #!/usr/bin/env php
 <?php
 
-// We define the root of the call
-define('BLACKSMITH_ROOT', getcwd());
-define('BLACKSMITH_COMMANDS_DIR', DIRECTORY_SEPARATOR . 'commands');
-
 // Autoload depending on where we are standing
 $project_autoload_path = __DIR__.'/../../autoload.php';
 $local_autoload_path   = __DIR__.'/vendor/autoload.php';
@@ -17,19 +13,28 @@ $autoload_path = file_exists($project_autoload_path)
 // Autoload classes
 require_once $autoload_path;
 
-// Get a console instance
-$console = new Blacksmith\Console($argv);
-
-// Tell the console which are the commands
-// we want available to use
-$console->commands = [
-    Blacksmith\Commands\HelpCommand::class,
-    Blacksmith\Commands\BootstrapCommand::class,
-    Blacksmith\Commands\MakeCmdCommand::class,
-    Blacksmith\Examples\SayHello::class,
-    Blacksmith\Examples\SayBye::class
+// Initialize app dependencies
+$dependencies = [
+    'blacksmith_root_path'     => getcwd(),
+    'blacksmith_commands_path' => getcwd() . DIRECTORY_SEPARATOR . 'commands',
+    'blacksmith_bin_path'      => 'vendor' . DIRECTORY_SEPARATOR . 'bin' . DIRECTORY_SEPARATOR . 'blacksmith',
+    'blacksmith_xml_path'      => getcwd() . DIRECTORY_SEPARATOR . 'blacksmith.xml',
+    'templates' => [
+        'blacksmith_xml_path' => 'templates' . DIRECTORY_SEPARATOR . 'config' . DIRECTORY_SEPARATOR . 'blacksmith.xml'
+    ]
 ];
 
-$console->handle();
+// Get a console instance
+$config  = new Blacksmith\Config($dependencies);
+$console = new Blacksmith\Console($config, $argv);
+
+try {
+
+    $console->handle();
+
+} catch (Exception $e) {
+
+    $console->getOutput()->println($e->getMessage(), 'red');
+}
 
 exit;

--- a/src/Command.php
+++ b/src/Command.php
@@ -41,14 +41,17 @@ abstract class Command {
         // get the raw arguments the console got
         $args = $this->console->getRawArguments();
 
-        // remove the "blacksmith" argument
-        // and remove the "command signature" argument
-        if ($args[0] === 'blacksmith' || $args[0] === $this::signature)
-            unset($args[0]);
+        if (!empty($args)) {
 
-        // remove the second parameter if it is the command signature
-        if ($args[1] === $this::signature)
-            unset($args[1]);
+            // remove the "blacksmith" argument
+            // and remove the "command signature" argument
+            if ($args[0] === 'blacksmith' || $args[0] === $this::signature)
+                unset($args[0]);
+
+            // remove the second parameter if it is the command signature
+            if ($args[1] === $this::signature)
+                unset($args[1]);
+        }
 
         return array_values($args);
     }

--- a/src/Commands/MakeCmdCommand.php
+++ b/src/Commands/MakeCmdCommand.php
@@ -4,6 +4,7 @@ namespace Blacksmith\Commands;
 
 use Blacksmith\Command;
 use Blacksmith\Arguments\MakeCmdArgument;
+use Blacksmith\Console;
 use Exception;
 
 /**
@@ -59,8 +60,7 @@ class MakeCmdCommand extends Command {
 
         // Validate argument was passed
         if (empty($args)) {
-            $this->console->output->alert('make:cmd requires an argument.');
-            return;
+            throw new Exception(self::signature . ' requires an argument.');
         }
 
         $this->arg = new MakeCmdArgument($args[0]);
@@ -74,12 +74,9 @@ class MakeCmdCommand extends Command {
      */
     protected function createSubDirectories()
     {
-        // Get the path to the /commands folder
-        $blacksmith_cmd_dir = BLACKSMITH_ROOT . BLACKSMITH_COMMANDS_DIR;
-
         // Form the full path with sub dirs for the new command
         // e.g. "my-project/commands/my/new/Cmd.php"
-        $this->command_dir_path = $blacksmith_cmd_dir . DIRECTORY_SEPARATOR . $this->arg->getSubDirPath();
+        $this->command_dir_path = $this->console->getConfig()->getBlacksmithCommandsPath() . DIRECTORY_SEPARATOR . $this->arg->getSubDirPath();
 
         if (!file_exists($this->command_dir_path)) {
             mkdir($this->command_dir_path, 0755, true);
@@ -100,27 +97,19 @@ class MakeCmdCommand extends Command {
     {
         $command_file_full_path = $this->command_dir_path . DIRECTORY_SEPARATOR . $this->arg->getCommandFileName();
 
-        try {
-
-            // Check if the command already exists
-            if (file_exists($command_file_full_path)) {
-                throw new Exception('Command already exists.');
-            }
-
-            // Create the file for the new command
-            $command_file = fopen($command_file_full_path, 'w');
-
-            // TODO: Create Script Generator to generate the PHP scripts for the new command.
-
-            fclose($command_file);
-
-        } catch (Exception $e) {
-
-            $this->console->output->alert($e->getMessage());
-            return;
+        // Check if the command already exists
+        if (file_exists($command_file_full_path)) {
+            throw new Exception('Command already exists.');
         }
 
-        $this->console->output->println('File created at: ' . $command_file_full_path);
-        $this->console->output->success('Command ' . $this->arg->getSignature() . ' created successfully.');
+        // Create the file for the new command
+        $command_file = fopen($command_file_full_path, 'w');
+
+        // TODO: Create Script Generator to generate the PHP scripts for the new command.
+
+        fclose($command_file);
+
+        $this->console->getOutput()->println('File created at: ' . $command_file_full_path);
+        $this->console->getOutput()->success('Command ' . $this->arg->getSignature() . ' created successfully.');
     }
 }

--- a/src/Config.php
+++ b/src/Config.php
@@ -1,0 +1,171 @@
+<?php
+
+namespace Blacksmith;
+
+/**
+ * The Config Class.
+ *
+ * This class is responsible for maintaining and validating configuration settings
+ * for the entire Blacksmith app.
+ */
+class Config {
+
+    /**
+     * The root path of the Blacksmith app.
+     * @var string
+     */
+    private $blacksmith_root_path;
+
+    /**
+     * The path to the "commands" directory.
+     * @var string
+     */
+    private $blacksmith_commands_path;
+
+    /**
+     * The path to the "blacksmith" binary executable.
+     * @var string
+     */
+    private $blacksmith_bin_path;
+
+    /**
+     * The path the blacksmith.xml configuration file.
+     * @var string
+     */
+    private $blacksmith_xml_path;
+
+    /**
+     * The path to the templates that are used for building scripts and
+     * configuration files.
+     * @var array
+     */
+    private $templates;
+
+    /**
+     * Constructor
+     *
+     * @param array $dependencies
+     *      The array of Blacksmith dependencies.
+     */
+    public function __construct($dependencies = [])
+    {
+        $this->setBlacksmithRootPath($dependencies['blacksmith_root_path']);
+        $this->setBlacksmithCommandsPath($dependencies['blacksmith_commands_path']);
+        $this->setBlacksmithBinPath($dependencies['blacksmith_bin_path']);
+        $this->setBlacksmithXmlPath($dependencies['blacksmith_xml_path']);
+        $this->setTemplates($dependencies['templates']);
+    }
+
+    /**
+     * Set the root directory path of the Blacksmith project.
+     *
+     * The path is an absolute path.
+     *
+     * @param string $blacksmith_root_path
+     *      The absolute path to the location of the Blacksmith project.
+     */
+    protected function setBlacksmithRootPath($blacksmith_root_path)
+    {
+        $this->blacksmith_root_path = $blacksmith_root_path;
+    }
+
+    /**
+     * Gets the root directory of the Blacksmith project.
+     *
+     * The path returned is an absolute path.
+     *
+     * @return string
+     */
+    public function getBlacksmithRootPath()
+    {
+        return $this->blacksmith_root_path;
+    }
+
+    /**
+     * Set the location of the Blacksmith "commands" directory which is
+     * where new commands are stored.
+     *
+     * @param string $blacksmith_commands_path
+     *      The absolute path of where new commands should be created in.
+     */
+    protected function setBlacksmithCommandsPath($blacksmith_commands_path)
+    {
+        $this->blacksmith_commands_path = $blacksmith_commands_path;
+    }
+
+    /**
+     * Gets the absolute path of the commands directory to the current project.
+     *
+     * The path returned is a absolute path.
+     *
+     * @return string
+     */
+    public function getBlacksmithCommandsPath()
+    {
+        return $this->blacksmith_commands_path;
+    }
+
+    /**
+     * Sets the path to the binary executable of the Blacksmith project.
+     *
+     * @param string $blacksmith_bin_path
+     *      The path of the binary executable.
+     */
+    protected function setBlacksmithBinPath($blacksmith_bin_path)
+    {
+        $this->blacksmith_bin_path = $blacksmith_bin_path;
+    }
+
+    /**
+     * Gets the path to the binary executable of the Blacksmith Project.
+     *
+     * @return string
+     */
+    public function getBlacksmithBinPath()
+    {
+        return $this->blacksmith_bin_path;
+    }
+
+    /**
+     * Sets the path to the blacksmith.xml command configuration file.
+     *
+     * @param string $blacksmith_xml_path
+     *      The path to the blacksmith.xml file.
+     */
+    protected function setBlacksmithXmlPath($blacksmith_xml_path)
+    {
+        $this->blacksmith_xml_path = $blacksmith_xml_path;
+    }
+
+    /**
+     * Gets the path to the blacksmith.xml file.
+     *
+     * @return string
+     */
+    public function getBlacksmithXmlPath()
+    {
+        return $this->blacksmith_xml_path;
+    }
+
+    /**
+     * Sets the list of paths to locate the templates files used for configuraton and
+     * new command generation.
+     * 
+     * @var array $templates
+     *      The array of paths to the templates.
+     */
+    protected function setTemplates($templates)
+    {
+        $this->templates = $templates;
+    }
+
+    /**
+     * Gets the list of paths of the template file locations.
+     *
+     * @return array
+     */
+    public function getTemplates()
+    {
+        return $this->templates;
+    }
+}

--- a/src/IO/Output.php
+++ b/src/IO/Output.php
@@ -33,7 +33,7 @@ class Output {
     {
         // If theres a color passed as a parameter
         // we paint the message in the requested color
-        if($color) {
+        if ($color) {
             $message = $this->decorator->decorate($message, $color);
         }
 

--- a/templates/config/blacksmith.xml
+++ b/templates/config/blacksmith.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0"?>
+<commands>
+    <command class="Blacksmith\Commands\HelpCommand"/>
+    <command class="Blacksmith\Commands\BootstrapCommand"/>
+    <command class="Blacksmith\Commands\MakeCmdCommand"/>
+    <command class="Blacksmith\Examples\SayHello"/>
+    <command class="Blacksmith\Examples\SayBye"/>
+</commands>

--- a/tests/Commands/BootstrapCommandTest.test.php
+++ b/tests/Commands/BootstrapCommandTest.test.php
@@ -1,0 +1,221 @@
+<?php
+
+namespace Blacksmith;
+
+use Blacksmith\Commands\BootstrapCommand;
+use Blacksmith\Console;
+use Blacksmith\IO\Output;
+use org\bovigo\vfs\vfsStream;
+use Exception;
+
+
+class BootstrapCommandTest extends \PHPUnit_Framework_TestCase {
+
+    /**
+     * The virtual root path.
+     * @var org\bovigo\vfs\vfsStream
+     */
+    protected $root;
+
+    /**
+     * The array of Blacksmith dependencies.
+     * @var array
+     */
+    protected $dependencies;
+
+    /**
+     * The mocked config object.
+     * @var Blacksmith\Config (Mocked)
+     */
+    protected $config;
+
+    public function setUp()
+    {
+        $this->root_dir_name = 'root';
+        $this->root          = vfsStream::setup($this->root_dir_name);
+        $this->root_path     = vfsStream::url($this->root_dir_name);
+
+        $this->dependencies = [
+            'blacksmith_root_path'     => $this->root_path,
+            'blacksmith_commands_path' => $this->root_path . DIRECTORY_SEPARATOR . 'commands',
+            'blacksmith_bin_path'      => 'vendor' . DIRECTORY_SEPARATOR . 'bin' . DIRECTORY_SEPARATOR . 'blacksmith',
+            'blacksmith_xml_path'      => $this->root_path . DIRECTORY_SEPARATOR . 'blacksmith.xml',
+            'templates' => [
+                'blacksmith_xml_path' => $this->root_path . DIRECTORY_SEPARATOR . 'templates' . DIRECTORY_SEPARATOR . 'config' . DIRECTORY_SEPARATOR . 'blacksmith.xml'
+            ]
+        ];
+
+        $this->createBlacksmithXmlTemplate();
+
+        $config = $this->getMockBuilder(Config::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $config->method('getBlacksmithRootPath')
+            ->will($this->returnValue($this->dependencies['blacksmith_root_path']));
+
+        $config->method('getBlacksmithBinPath')
+            ->will($this->returnValue($this->dependencies['blacksmith_bin_path']));
+
+        $config->method('getBlacksmithCommandsPath')
+            ->will($this->returnValue($this->dependencies['blacksmith_commands_path']));
+
+        $config->method('getBlacksmithXmlPath')
+            ->will($this->returnValue($this->dependencies['blacksmith_xml_path']));
+
+        $config->method('getTemplates')
+            ->will($this->returnValue($this->dependencies['templates']));
+
+        $this->config = $config;
+    }
+
+    public function tearDown()
+    {
+        $this->root         = null;
+        $this->root_path    = null;
+        $this->dependencies = null;
+    }
+
+    /**
+     * Sets up a test template blacksmith.xml file.
+     */
+    public function createBlacksmithXmlTemplate()
+    {
+        $xml_template_dir  = vfsStream::url($this->root_dir_name . '/templates/config');
+        $xml_template_file = $xml_template_dir . '/blacksmith.xml';
+
+        mkdir($xml_template_dir, 0755, true);
+        touch($xml_template_file);
+        file_put_contents($xml_template_file, 'Test Content');
+    }
+
+    public function testRunningBootstrapCommandCreatesCommandsDirectory()
+    {
+        $raw_arguments = [
+            'blacksmith',
+            'bootstrap'
+        ];
+
+        $output = $this->getMockBuilder(Output::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $output->method('println')
+            ->with($this->anything())
+            ->will($this->returnValue('Line printed.'));
+
+        $console = $this->getMockBuilder(Console::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $console->method('getOutput')
+            ->will($this->returnValue($output));
+
+        $console->method('getRawArguments')
+            ->will($this->returnValue($raw_arguments));
+
+        $console->method('getConfig')
+            ->will($this->returnValue($this->config));
+
+        $command = new BootstrapCommand($console);
+        $command->run();
+
+        $expected_result = 'commands';
+
+        $this->assertTrue($this->root->hasChild($expected_result));
+    }
+
+    public function testBootstrapCommandProperlyCreatesBlacksmithXmlFileWhenRun()
+    {
+        $raw_arguments = [
+            'blacksmith',
+            'bootstrap'
+        ];
+
+        $output = $this->getMockBuilder(Output::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $output->method('println')
+            ->with($this->anything())
+            ->will($this->returnValue('Line printed.'));
+
+        $console = $this->getMockBuilder(Console::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $console->method('getRawArguments')
+            ->will($this->returnValue($raw_arguments));
+
+        $console->method('getOutput')
+            ->will($this->returnValue($output));
+
+        $console->method('getConfig')
+            ->will($this->returnValue($this->config));
+
+        $command = new BootstrapCommand($console);
+        $command->run();
+
+        $expected_result = 'blacksmith.xml';
+
+        $this->assertTrue($this->root->hasChild($expected_result));
+    }
+
+    /**
+     * @expectedException Exception
+     */
+    public function testBootstrapCommandThrowsExceptionIfNameOptionIsProvidedWithNoArgument()
+    {
+        $raw_arguments = [
+            'blacksmith',
+            'bootstrap',
+            '-n'
+        ];
+
+        $console = $this->getMockBuilder(Console::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $console->method('getRawArguments')
+            ->will($this->returnValue($raw_arguments));
+
+        $command = new BootstrapCommand($console);
+        $command->run();
+    }
+
+    public function testBootstrapCommandProperlyCopiesOverDefaultXmlCommandConfigurationSettingsFromTemplate()
+    {
+        $raw_arguments = [
+            'blacksmith',
+            'bootstrap'
+        ];
+
+        $output = $this->getMockBuilder(Output::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $output->method('println')
+            ->with($this->anything())
+            ->will($this->returnValue('Line printed.'));
+
+        $console = $this->getMockBuilder(Console::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $console->method('getRawArguments')
+            ->will($this->returnValue($raw_arguments));
+
+        $console->method('getOutput')
+            ->will($this->returnValue($output));
+
+        $console->method('getConfig')
+            ->will($this->returnValue($this->config));
+
+        $command = new BootstrapCommand($console);
+        $command->run();
+
+        $template_content = file_get_contents($this->root_path . '/blacksmith.xml');
+
+        $this->assertEquals('Test Content', $template_content);
+    }
+}

--- a/tests/Commands/MakeCmdCommandTest.test.php
+++ b/tests/Commands/MakeCmdCommandTest.test.php
@@ -1,0 +1,128 @@
+<?php
+
+namespace Blacksmith;
+
+use Blacksmith\Commands\MakeCmdCommand;
+use Blacksmith\Console;
+use Blacksmith\IO\Output;
+use org\bovigo\vfs\vfsStream;
+use Exception;
+
+
+class MakeCmdCommandTest extends \PHPUnit_Framework_TestCase {
+
+    /**
+     * Specifies the root directory for the virtual files system (vfs).
+     * @var vfsStreamDirectory
+     */
+    protected $root;
+
+    public function setUp()
+    {
+        $this->root_path         = 'root';
+        $this->virtual_root_path = vfsStream::setup($this->root_path);
+    }
+
+    public function testRunningMakeCmdCommandCreatesFileCorrectlyInSpecifiedFilePath()
+    {
+        $arguments = [
+            'blacksmith',
+            'make:cmd',
+            'some/file/path'
+        ];
+
+        $output = $this->getMockBuilder(Output::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $output->method('println')
+            ->with($this->anything())
+            ->will($this->returnValue('Line printed.'));
+
+        $output->method('success')
+            ->with($this->anything())
+            ->will($this->returnValue('Success line printed.'));
+
+        $config = $this->getMockBuilder(Config::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $config->method('getBlacksmithCommandsPath')
+            ->will($this->returnValue(vfsStream::url($this->root_path . '/commands')));
+
+        $console = $this->getMockBuilder(Console::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $console->method('getRawArguments')
+            ->will($this->returnValue($arguments));
+
+        $console->method('getOutput')
+            ->will($this->returnValue($output));
+
+        $console->method('getConfig')
+            ->will($this->returnValue($config));
+
+        $command = new MakeCmdCommand($console);
+        $command->run();
+
+        $expected_result = 'commands/some/file/Path.php';
+
+        $this->assertTrue($this->virtual_root_path->hasChild($expected_result));
+    }
+
+    /**
+     * @expectedException Exception
+     */
+    public function testMakeCmdCommandDoesNotRunIfNoArgumentsArePassed()
+    {
+        $console = $this->getMockBuilder(Console::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $console->method('getRawArguments')
+            ->will($this->returnValue([]));
+
+        $command = new MakeCmdCommand($console);
+        $command->run();
+    }
+
+    /**
+     * @expectedException Exception
+     */
+    public function testMakeCmdCommandThrowsExceptionIfCommandProvidedAlreadyExists()
+    {
+        $existing_dir = vfsStream::url($this->root_path . '/commands/file/already');
+        $existing_file = $existing_dir . '/Exists.php';
+
+        // Make the file exist by creating it in the VFS
+        mkdir($existing_dir, 0755, true);
+        touch($existing_file);
+
+        $arguments = [
+            'blacksmith',
+            'make:cmd',
+            'file/already/exists'
+        ];
+
+        $config = $this->getMockBuilder(Config::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $config->method('getBlacksmithCommandsPath')
+            ->will($this->returnValue(vfsStream::url($this->root_path . '/commands')));
+
+        $console = $this->getMockBuilder(Console::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $console->method('getRawArguments')
+            ->will($this->returnValue($arguments));
+
+        $console->method('getConfig')
+            ->will($this->returnValue($config));
+
+        $command = new MakeCmdCommand($console);
+        $command->run();
+    }
+}

--- a/tests/ConfigTest.test.php
+++ b/tests/ConfigTest.test.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Blacksmith;
+
+use Blacksmith\Config;
+use org\bovigo\vfs\vfsStream;
+use Exception;
+
+
+class ConfigTest extends \PHPUnit_Framework_TestCase {
+
+    /**
+     * The virtual root path.
+     * @var org\bovigo\vfs\vfsStream
+     */
+    protected $root;
+
+    /**
+     * The array of Blacksmith dependencies.
+     * @var array
+     */
+    protected $dependencies;
+
+    public function setUp()
+    {
+        $this->root = vfsStream::setup('root');
+        $this->root_path = vfsStream::url('root');
+
+        $this->dependencies = [
+            'blacksmith_root_path'     => $this->root_path,
+            'blacksmith_commands_path' => $this->root_path . DIRECTORY_SEPARATOR . 'commands',
+            'blacksmith_bin_path'      => 'vendor' . DIRECTORY_SEPARATOR . 'bin' . DIRECTORY_SEPARATOR . 'blacksmith',
+            'blacksmith_xml_path'      => $this->root_path . DIRECTORY_SEPARATOR . 'blacksmith.xml',
+            'templates' => [
+                'blacksmith_xml_path' => 'templates' . DIRECTORY_SEPARATOR . 'config' . DIRECTORY_SEPARATOR . 'blacksmith.xml'
+            ]
+        ];
+    }
+
+    public function testDependenciesProperlyGetSetToConfigWhenPassedThroughConstructor()
+    {
+        $config = new Config($this->dependencies);
+
+        $this->assertEquals($this->dependencies['blacksmith_root_path'], $config->getBlacksmithRootPath());
+        $this->assertEquals($this->dependencies['blacksmith_commands_path'], $config->getBlacksmithCommandsPath());
+        $this->assertEquals($this->dependencies['blacksmith_bin_path'], $config->getBlacksmithBinPath());
+        $this->assertEquals($this->dependencies['blacksmith_xml_path'], $config->getBlacksmithXmlPath());
+        $this->assertEquals($this->dependencies['templates'], $config->getTemplates());
+    }
+}

--- a/tests/ConsoleTest.test.php
+++ b/tests/ConsoleTest.test.php
@@ -3,6 +3,7 @@
 namespace Blacksmith;
 
 use Blacksmith\Console;
+use org\bovigo\vfs\vfsStream;
 
 
 class ConsoleTest extends \PHPUnit_Framework_TestCase {
@@ -13,17 +14,64 @@ class ConsoleTest extends \PHPUnit_Framework_TestCase {
 
     protected function setUp()
     {
-        $this->console = new Console;
+        $this->root = vfsStream::setup('root');
+        $this->root_path = vfsStream::url('root');
 
-        $this->console->setRawArguments([
-            0 => 'blacksmith',
-            1 => 'make:command'
-        ]);
+        $this->createBlacksmithXmlFile();
 
-        $this->console->commands = [
-            TestCommandMock::class,
-            TestCommand2Mock::class
+        $dependencies = [
+            'blacksmith_root_path'     => $this->root_path,
+            'blacksmith_commands_path' => $this->root_path . '/commands',
+            'blacksmith_bin_path'      => 'vendor/bin/blacksmith',
+            'blacksmith_xml_path'      => $this->root_path . '/blacksmith.xml',
+            'templates' => [
+                'blacksmith_xml_path' => $this->root_path . '/templates/config/blacksmith.xml'
+            ]
         ];
+
+        $config = $this->getMockBuilder(Config::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $config->method('getBlacksmithRootPath')
+            ->will($this->returnValue($dependencies['blacksmith_root_path']));
+
+        $config->method('getBlacksmithBinPath')
+            ->will($this->returnValue($dependencies['blacksmith_bin_path']));
+
+        $config->method('getBlacksmithCommandsPath')
+            ->will($this->returnValue($dependencies['blacksmith_commands_path']));
+
+        $config->method('getBlacksmithXmlPath')
+            ->will($this->returnValue($dependencies['blacksmith_xml_path']));
+
+        $config->method('getTemplates')
+            ->will($this->returnValue($dependencies['templates']));
+
+        $raw_arguments = [
+            'blacksmith',
+            'make:command'
+        ];
+
+        $this->console = new Console($config, $raw_arguments);
+    }
+
+    /**
+     * Creates a mock xml file in place of blacksmith.xml, which is used to
+     * hold the list of available commands.
+     */
+    public function createBlacksmithXmlFile()
+    {
+        $commands_xml = '<?xml version="1.0"?>' .
+            '<commands>' .
+                '<command class="Blacksmith\TestCommandMock"/>' .
+                '<command class="Blacksmith\TestCommand2Mock"/>' .
+            '</commands>';
+
+        $commands_xml_file = $this->root_path . '/blacksmith.xml';
+
+        touch($commands_xml_file);
+        file_put_contents($commands_xml_file, $commands_xml);
     }
 
 


### PR DESCRIPTION
…dencies, new and updated tests.

**Changes in `blacksmith` file**

* Created Config object `Blacksmith\Config` to manage app-wide dependencies. As of now it really just holds path constants that were formerly `BLACKSMITH_ROOT` and `BLACKSMITH_COMMANDS_DIR`.
* `php blacksmith bootstrap` command now generates an XML configuration file at `./blacksmith.xml` with the following registered commands:

```xml
    <?xml version="1.0"?>
    <commands>
        <command class="Blacksmith\Commands\HelpCommand"/>
        <command class="Blacksmith\Commands\BootstrapCommand"/>
        <command class="Blacksmith\Commands\MakeCmdCommand"/>
        <command class="Blacksmith\Examples\SayHello"/>
        <command class="Blacksmith\Examples\SayBye"/>
    </commands>
```

This XML configuration is copied over from `./templates/config/blacksmith.xml`. The `./templates/*` directory is meant to hold blacksmith default configurations and "templates" such as the initial Blacksmith commands you should get when you run `php blacksmith bootstrap` and the template PHP script that should be dynamically generated when running `php blacksmith make:cmd <commandname>`.
* The `Blacksmith\Console` class now accepts the `Blacksmith\Config` object as the second constructor parameter.
* Changed console error messages within the codebase to throw Exceptions instead. These exception messages should now float all the way to the top of the application layer at `./blacksmith` and be caught there. This allows for cleaner code that admits failure much more clearly, it removes arbitrary `return;` statements at the end of an error console message, and it allows for easier unit testing.

---

**Changes in `src/Command.php`**

* Added `!empty($args)` conditional in `getArguments()` to prevent the potential of an "out of bounds" index exception, in case getting the raw arguments returns an empty set. This is because trying to access the variable at `$args[1]` has the potential to throw an exception.

---

**Changes in `src/Commands/BootstrapCommand.php`**

* Added `initializeBlacksmithXmlFile()` method which creates the `blacksmith.xml` file in the target external project.
* For `copyBlacksmithToRoot()` method, I changed the `vendor/bin/blacksmith` path to be built via `Blacksmith\Config` properties. This makes it easier to unit test since the constant it was using before (`BLACKSMITH_ROOT . 'vendor/bin/blacksmith'`) does not unwantingly become undefined in unit tests.

---

**Changes in `src/Commands/MakeCmdCommand.php`**

* Change console error messages throw Exception instead.
* Changed some of the calls to to use paths from the `Blacksmith\Config` object instead of using constants and hardcoded paths directly.

---

**Changes in `src/Console.php`**

* Added `Blacksmith\Config` object as mandatory constructor parameter.
* Created a setter and getter for the `Output` class.
* Created a setter and getter for the `Blacksmith\Config` class.
* Created `loadCommands()` method that loads commands from the `blacksmith.xml` configuration file. If there is no `blacksmith.xml` file found in the target external project, then we use the one in the core app from `templates/config/blacksmith.xml` as the default XML config file.

---

**Changes in `src/IO/Output`**

* Fixed spacing for an if statement. It looked scrunched together.

---

**Testing**

* Updated `ConsoleTest` to reflect new changes and to mock the `Blacksmith\Config` class.
* Now uses `vfsStream` to test that the `loadCommands()` method which reads the registered commands from `blacksmith.xml` is properly loading in commands.

---

**New Files**

* `src\Config.php` - holds configuration dependencies for the app. Makes unit testing much simpler.
* `templates/` - Directory used to hold default configurations and "templates".
* `tests/Commands/` - Added unit tests for `make:cmd` and `bootstrap` commands.
* `tests/ConfigTest.test.php` - Unit tests for the new `Blacksmith\Config` object.
